### PR TITLE
[Bug] Cypress를 테스트 커버리지에서 제외합니다 (이슈 #2)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,7 @@ module.exports = {
   coveragePathIgnorePatterns: [
     '<rootDir>/node_modules/',
     '<rootDir>/coverage/',
+    '<rootDir>/cypress/',
     '<rootDir>/.next/',
     'jest.config.js',
     'next.config.js',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-starter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "nextjs starter",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
# Cypress를 테스트 커버리지에서 제외합니다
## 구현
- [x] Cypress를 테스트 커버리지에서 제외
- [x] 버전업 v.1.0.1

## 이슈
- [x] 없음

## 참조
- #2 
