### PR TITLE
[Bug] ESLint 이슈를 해결합니다 (Cypress.Chai 와 Jest 타입 충돌) (이슈 #122)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,8 @@
     "**/*.tsx"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "cypress",
+    "cypress.config.ts",
   ]
 }


### PR DESCRIPTION
# ESLint 이슈를 해결합니다 (Cypress.Chai 와 Jest 타입 충돌)
## 구현
- [x] ESLint 이슈 해결
- [x] Cypress를 TS 체크 영역에서 제외 

## 이슈
- [x] Type 체크시에 Jest를 Chai로 인식하는 문제

## 참조
- #122
- [Cypress PR 내역](https://github.com/cypress-io/cypress/issues/22059)
