### PR TITLE
[Hotfix] CLI 폴더 제거 경로를 올바르게 고쳐라

### DIFF
--- a/bin/validator.js
+++ b/bin/validator.js
@@ -68,7 +68,7 @@ const setupPackage = (projectName, projectPath) => {
   fs.unlinkSync(path.join(projectPath, 'LICENSE'));
   fs.unlinkSync(path.join(projectPath, 'renovate.json'));
 
-  fs.rmSync('./github', { recursive: true });
+  fs.rmSync('./.github', { recursive: true });
   fs.rmSync('./.git', { recursive: true });
   fs.rmSync('./bin', { recursive: true });
 


### PR DESCRIPTION
# CLI 폴더 제거 경로를 올바르게 고쳐라
## 내용
- [x] .github 폴더 경로를 올바르게 정정
